### PR TITLE
feat: add MiniMax as built-in LLM provider with presets system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # GitHub Token for extending Rate Limit (Optional)
 GITHUB_TOKEN=
 
+# LLM Provider Selection (Optional)
+# Supported providers: openai, minimax, deepseek, ollama
+# If omitted, auto-detected from LLM_BASE_URL or API key env vars.
+LLM_PROVIDER=
+
 # LLM Configuration (Optional, fallback to Ollama if empty)
 # Use 'local-fallback' for local LLMs, or your specific provider KEY
 LLM_API_KEY=
@@ -8,8 +13,13 @@ LLM_API_KEY=
 # Local or Remote LLM URL (Ollama example: http://127.0.0.1:11434/v1)
 LLM_BASE_URL=
 
-# Model Name (e.g., gpt-4o-mini, llama3, deepseek-chat)
+# Model Name (e.g., gpt-4o-mini, MiniMax-M2.5, deepseek-chat, llama3)
 LLM_MODEL=
+
+# Provider-specific API keys (used when LLM_API_KEY is not set)
+# OPENAI_API_KEY=
+# MINIMAX_API_KEY=
+# DEEPSEEK_API_KEY=
 
 # Batch Sizes
 BATCH_SIZE=5

--- a/README-zh.md
+++ b/README-zh.md
@@ -134,14 +134,34 @@ cp .env.example .env
 - **`GITHUB_TOKEN=`** `(强烈建议配置)`：搜索限流极高，不置为空很容易触发限流风控。
 - **`LLM_API_KEY=`**：你的 大语言模型 API Key（用于分析和筛选项目）。
   - *💡 零成本本地提示：如果你在使用本地部署大模型（如 Ollama + llama3），可以将其设为 `local-fallback`。*
+- **`LLM_PROVIDER=`**：选择内置供应商预设（`openai`、`minimax`、`deepseek`、`ollama`）。省略时会根据 `LLM_BASE_URL` 或对应的 API Key 环境变量自动检测。
 - **`LLM_BASE_URL=`**：API转发地址（例如：`https://api.openai.com/v1` 或 本地 `http://127.0.0.1:11434/v1`）。
-- **`LLM_MODEL=`**：要执行推理的模型名字。
+- **`LLM_MODEL=`**：要执行推理的模型名字（如 `gpt-4o-mini`、`MiniMax-M2.5`）。
 - **`DISCOVER_BATCH_SIZE`** / **`EVALUATE_BATCH_SIZE`**：可控每次探索拉取的个数，及一次批量合并扔给 AI 判断的项目个数。
 - **`LOOP_INTERVAL_SECONDS`**: 可调整 `ai:loop-eval` 循环模式每次休息的打底时间（默认 60 秒）。
 - **`MAX_PAGES_DEFAULT`**: 每个话题默认探索的最大页数（默认：5）。
 - **`MAX_PAGES_QUALITY`**: 高质量话题探索的最大页数（默认：20）。
 - **`QUALITY_TOPIC_THRESHOLD`**: 判定为高质量话题的分数阈值（默认：5）。
 - **`AUTO_FETCH_DESC_STARS`**: 自动获取缺失描述的 Star 阈值（默认：1000）。
+
+#### 支持的 LLM 供应商
+
+评估引擎支持任何 **OpenAI 兼容** 的 LLM API，内置预设可方便切换：
+
+| 供应商 | `LLM_PROVIDER` | 默认模型 | API Key 环境变量 |
+|--------|----------------|----------|-----------------|
+| [OpenAI](https://openai.com) | `openai` | `gpt-4o-mini` | `OPENAI_API_KEY` 或 `LLM_API_KEY` |
+| [MiniMax](https://www.minimaxi.com) | `minimax` | `MiniMax-M2.5` | `MINIMAX_API_KEY` 或 `LLM_API_KEY` |
+| [DeepSeek](https://deepseek.com) | `deepseek` | `deepseek-chat` | `DEEPSEEK_API_KEY` 或 `LLM_API_KEY` |
+| [Ollama](https://ollama.ai) (本地) | `ollama` | `llama3` | 不需要（使用 `local-fallback`） |
+
+**MiniMax 快速上手：**
+```bash
+LLM_PROVIDER=minimax
+MINIMAX_API_KEY=your-key-here
+# 可选指定模型：
+# LLM_MODEL=MiniMax-M2.7
+```
 
 ### 3. 开始执行自动化作业
 您可以按照需求来跑跑脚本：

--- a/README.md
+++ b/README.md
@@ -125,14 +125,34 @@ Open `.env` and adjust the core configurations:
 - **`GITHUB_TOKEN=`** `(Highly Recommended)`: Bypasses the strict rate limits applied to anonymous GitHub search API calls.
 - **`LLM_API_KEY=`**: Your target LLM API Key (used for analyzing and curating projects).
   - *💡 Zero-Cost Prompt: If you are using a local LLM setup (e.g. Ollama via llama3), you can simply use `LLM_API_KEY=local-fallback`.*
+- **`LLM_PROVIDER=`**: Select a built-in provider preset (`openai`, `minimax`, `deepseek`, `ollama`). When omitted, auto-detected from `LLM_BASE_URL` or provider-specific API key env vars.
 - **`LLM_BASE_URL=`**: LLM endpoint (e.g. `https://api.openai.com/v1`, or local `http://127.0.0.1:11434/v1`).
-- **`LLM_MODEL=`**: Standard model identity to use (e.g. `gpt-4o-mini`).
+- **`LLM_MODEL=`**: Standard model identity to use (e.g. `gpt-4o-mini`, `MiniMax-M2.5`).
 - **`DISCOVER_BATCH_SIZE`** / **`EVALUATE_BATCH_SIZE`**: Modify limits per pull from GitHub and per LLM prompt bulk execution batch.
 - **`LOOP_INTERVAL_SECONDS`**: Configure the base idle time interval between consecutive `ai:loop-eval` cycles (default: 60s).
 - **`MAX_PAGES_DEFAULT`**: Default max pages to explore per topic (default: 5).
 - **`MAX_PAGES_QUALITY`**: Max pages for high-quality topics (default: 20).
 - **`QUALITY_TOPIC_THRESHOLD`**: Score threshold for high-quality topics (default: 5).
 - **`AUTO_FETCH_DESC_STARS`**: Star threshold to proactively fetch missing descriptions (default: 1000).
+
+#### Supported LLM Providers
+
+The evaluation engine supports any **OpenAI-compatible** LLM API. Built-in presets make it easy to switch:
+
+| Provider | `LLM_PROVIDER` | Default Model | API Key Env |
+|----------|----------------|---------------|-------------|
+| [OpenAI](https://openai.com) | `openai` | `gpt-4o-mini` | `OPENAI_API_KEY` or `LLM_API_KEY` |
+| [MiniMax](https://www.minimaxi.com) | `minimax` | `MiniMax-M2.5` | `MINIMAX_API_KEY` or `LLM_API_KEY` |
+| [DeepSeek](https://deepseek.com) | `deepseek` | `deepseek-chat` | `DEEPSEEK_API_KEY` or `LLM_API_KEY` |
+| [Ollama](https://ollama.ai) (local) | `ollama` | `llama3` | N/A (uses `local-fallback`) |
+
+**Quick start with MiniMax:**
+```bash
+LLM_PROVIDER=minimax
+MINIMAX_API_KEY=your-key-here
+# Optionally pick a specific model:
+# LLM_MODEL=MiniMax-M2.7
+```
 
 ### 3. Run Automation Pipelines
 Choose how you want to execute scripts:

--- a/scripts/discover-and-evaluate.js
+++ b/scripts/discover-and-evaluate.js
@@ -11,9 +11,9 @@ const queueFile = path.join(__dirname, '../data/pending-projects.json');
 const topicsFile = path.join(__dirname, '../data/topics.json');
 const rejectedFile = path.join(__dirname, '../data/rejected-projects.json');
 
-const LLM_API_KEY = process.env.LLM_API_KEY || 'local-fallback';
-const LLM_BASE_URL = process.env.LLM_BASE_URL || (LLM_API_KEY === 'local-fallback' ? 'http://127.0.0.1:11434/v1' : 'https://api.openai.com/v1');
-const LLM_MODEL = process.env.LLM_MODEL || (LLM_API_KEY === 'local-fallback' ? 'llama3' : 'gpt-4o-mini');
+import { resolveLLMConfig, buildRequestBody, stripThinkTags } from './llm-provider.js';
+
+const { provider: LLM_PROVIDER, baseUrl: LLM_BASE_URL, apiKey: LLM_API_KEY, model: LLM_MODEL } = resolveLLMConfig();
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const DISCOVER_BATCH_SIZE = parseInt(process.env.DISCOVER_BATCH_SIZE || '10', 10);
@@ -54,21 +54,23 @@ function saveJson(filePath, data) {
 }
 
 async function askLLM(prompt) {
+  const messages = [
+    { role: 'system', content: 'You are an AI project curator. Your job is to strictly evaluate GitHub repositories and return JSON. Respond ONLY with valid JSON.' },
+    { role: 'user', content: prompt }
+  ];
+
+  const body = buildRequestBody(LLM_PROVIDER, LLM_MODEL, messages, {
+    temperature: 0.1,
+    responseFormat: { type: "json_object" },
+  });
+
   const res = await fetch(`${LLM_BASE_URL}/chat/completions`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${LLM_API_KEY}`
     },
-    body: JSON.stringify({
-      model: LLM_MODEL,
-      messages: [
-        { role: 'system', content: 'You are an AI project curator. Your job is to strictly evaluate GitHub repositories and return JSON. Respond ONLY with valid JSON.' },
-        { role: 'user', content: prompt }
-      ],
-      temperature: 0.1,
-      response_format: { type: "json_object" }
-    })
+    body: JSON.stringify(body)
   });
 
   if (!res.ok) {
@@ -77,7 +79,8 @@ async function askLLM(prompt) {
   }
 
   const resData = await res.json();
-  const content = resData.choices[0].message.content;
+  let content = resData.choices[0].message.content;
+  content = stripThinkTags(content);
   let cleanContent = content.replace(/```json/g, '').replace(/```/g, '').trim();
   return JSON.parse(cleanContent);
 }
@@ -378,7 +381,7 @@ async function evaluate() {
 
   const totalPending = pendingDb.queue.length;
   console.log(`\n📊 [Task Pool] Current pending tasks awaiting evaluation: ${totalPending}`);
-  console.log(`🤖 [Task Pool] Evaluating up to ${EVALUATE_BATCH_SIZE} projects using Model: ${LLM_MODEL}...`);
+  console.log(`🤖 [Task Pool] Evaluating up to ${EVALUATE_BATCH_SIZE} projects using Provider: ${LLM_PROVIDER}, Model: ${LLM_MODEL}...`);
 
   // Grab up to EVALUATE_BATCH_SIZE items
   const batch = pendingDb.queue.splice(0, EVALUATE_BATCH_SIZE);

--- a/scripts/llm-provider.js
+++ b/scripts/llm-provider.js
@@ -1,0 +1,149 @@
+/**
+ * LLM Provider Presets & Configuration
+ *
+ * Supports multiple LLM providers via OpenAI-compatible API.
+ * Provider can be selected via the LLM_PROVIDER env var, or auto-detected
+ * from LLM_API_KEY / LLM_BASE_URL.
+ */
+
+/** Built-in provider presets */
+const PROVIDER_PRESETS = {
+  openai: {
+    name: 'OpenAI',
+    baseUrl: 'https://api.openai.com/v1',
+    defaultModel: 'gpt-4o-mini',
+    envKey: 'OPENAI_API_KEY',
+    temperatureRange: [0, 2],
+  },
+  minimax: {
+    name: 'MiniMax',
+    baseUrl: 'https://api.minimax.io/v1',
+    defaultModel: 'MiniMax-M2.5',
+    envKey: 'MINIMAX_API_KEY',
+    temperatureRange: [0, 1],
+    models: ['MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+  },
+  deepseek: {
+    name: 'DeepSeek',
+    baseUrl: 'https://api.deepseek.com/v1',
+    defaultModel: 'deepseek-chat',
+    envKey: 'DEEPSEEK_API_KEY',
+    temperatureRange: [0, 2],
+  },
+  ollama: {
+    name: 'Ollama (Local)',
+    baseUrl: 'http://127.0.0.1:11434/v1',
+    defaultModel: 'llama3',
+    envKey: null,
+    temperatureRange: [0, 2],
+  },
+};
+
+/**
+ * Auto-detect provider from API key or base URL.
+ */
+function detectProvider(apiKey, baseUrl) {
+  if (baseUrl) {
+    if (baseUrl.includes('minimax')) return 'minimax';
+    if (baseUrl.includes('deepseek')) return 'deepseek';
+    if (baseUrl.includes('openai.com')) return 'openai';
+    if (baseUrl.includes('127.0.0.1') || baseUrl.includes('localhost')) return 'ollama';
+  }
+  if (process.env.MINIMAX_API_KEY) return 'minimax';
+  if (process.env.DEEPSEEK_API_KEY) return 'deepseek';
+  if (apiKey && apiKey !== 'local-fallback') return 'openai';
+  return 'ollama';
+}
+
+/**
+ * Clamp temperature to the provider's accepted range.
+ */
+function clampTemperature(temperature, providerName) {
+  const preset = PROVIDER_PRESETS[providerName];
+  if (!preset) return temperature;
+  const [min, max] = preset.temperatureRange;
+  return Math.min(Math.max(temperature, min), max);
+}
+
+/**
+ * Resolve the full LLM configuration from environment variables.
+ *
+ * Priority:
+ *   1. Explicit LLM_PROVIDER env var
+ *   2. Auto-detection from LLM_BASE_URL / API keys
+ *   3. Fallback to 'ollama' when no API key is set
+ *
+ * Returns { provider, baseUrl, apiKey, model, preset }
+ */
+function resolveLLMConfig() {
+  const explicitProvider = (process.env.LLM_PROVIDER || '').toLowerCase();
+  const rawApiKey = process.env.LLM_API_KEY || '';
+  const rawBaseUrl = process.env.LLM_BASE_URL || '';
+  const rawModel = process.env.LLM_MODEL || '';
+
+  // Determine provider
+  let provider;
+  if (explicitProvider && PROVIDER_PRESETS[explicitProvider]) {
+    provider = explicitProvider;
+  } else {
+    provider = detectProvider(rawApiKey, rawBaseUrl);
+  }
+
+  const preset = PROVIDER_PRESETS[provider];
+
+  // Resolve API key: explicit LLM_API_KEY > provider-specific env key > local-fallback
+  let apiKey = rawApiKey;
+  if (!apiKey && preset.envKey) {
+    apiKey = process.env[preset.envKey] || '';
+  }
+  if (!apiKey) apiKey = 'local-fallback';
+
+  // Resolve base URL
+  const baseUrl = rawBaseUrl || preset.baseUrl;
+
+  // Resolve model
+  const model = rawModel || preset.defaultModel;
+
+  return { provider, baseUrl, apiKey, model, preset };
+}
+
+/**
+ * Build the request body for a chat completion call.
+ * Applies provider-specific adjustments (e.g. temperature clamping).
+ */
+function buildRequestBody(provider, model, messages, options = {}) {
+  const temperature = clampTemperature(
+    options.temperature ?? 0.1,
+    provider
+  );
+
+  const body = {
+    model,
+    messages,
+    temperature,
+  };
+
+  // response_format is widely supported by OpenAI-compatible APIs
+  if (options.responseFormat) {
+    body.response_format = options.responseFormat;
+  }
+
+  return body;
+}
+
+/**
+ * Strip <think>…</think> tags that some models (e.g. MiniMax-M2.5) may
+ * include in their responses.
+ */
+function stripThinkTags(text) {
+  return text.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+}
+
+export {
+  PROVIDER_PRESETS,
+  detectProvider,
+  clampTemperature,
+  resolveLLMConfig,
+  buildRequestBody,
+  stripThinkTags,
+};

--- a/tests/llm-provider.integration.test.js
+++ b/tests/llm-provider.integration.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveLLMConfig, buildRequestBody, stripThinkTags } from '../scripts/llm-provider.js';
+
+/**
+ * Integration tests for LLM provider module.
+ *
+ * These tests verify end-to-end provider configuration resolution and
+ * request building across different provider scenarios.
+ *
+ * Tests marked with `MINIMAX_API_KEY` in the environment will attempt
+ * a live API call to verify connectivity.
+ */
+
+describe('Integration: provider config resolution', () => {
+  const envBackup = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.LLM_PROVIDER;
+    delete process.env.LLM_API_KEY;
+    delete process.env.LLM_BASE_URL;
+    delete process.env.LLM_MODEL;
+    delete process.env.MINIMAX_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...envBackup };
+  });
+
+  it('should produce a valid MiniMax chat completion request body', () => {
+    process.env.LLM_PROVIDER = 'minimax';
+    process.env.MINIMAX_API_KEY = 'test-key';
+
+    const config = resolveLLMConfig();
+    const messages = [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: 'Hello' },
+    ];
+
+    const body = buildRequestBody(config.provider, config.model, messages, {
+      temperature: 0.1,
+      responseFormat: { type: 'json_object' },
+    });
+
+    expect(body.model).toBe('MiniMax-M2.5');
+    expect(body.temperature).toBe(0.1);
+    expect(body.response_format).toEqual({ type: 'json_object' });
+    expect(body.messages).toHaveLength(2);
+
+    // Verify the full request URL would be correct
+    const url = `${config.baseUrl}/chat/completions`;
+    expect(url).toBe('https://api.minimax.io/v1/chat/completions');
+  });
+
+  it('should auto-detect MiniMax and resolve full config from MINIMAX_API_KEY alone', () => {
+    process.env.MINIMAX_API_KEY = 'mm-test-key';
+
+    const config = resolveLLMConfig();
+    expect(config.provider).toBe('minimax');
+    expect(config.baseUrl).toBe('https://api.minimax.io/v1');
+    expect(config.model).toBe('MiniMax-M2.5');
+    expect(config.apiKey).toBe('mm-test-key');
+  });
+
+  it('should handle MiniMax response with think tags in JSON output', () => {
+    const rawResponse = `<think>
+Let me evaluate these projects...
+Project 1 looks good for the agents category.
+Project 2 is not AI-related.
+</think>
+{
+  "evaluations": [
+    {
+      "id": 0,
+      "is_valuable": true,
+      "category_id": "agents",
+      "project": { "name": "test-agent", "description": "测试代理", "tags": ["agent"], "health": "Active" }
+    },
+    {
+      "id": 1,
+      "is_valuable": false,
+      "reason": "Not AI-related"
+    }
+  ]
+}`;
+
+    const cleaned = stripThinkTags(rawResponse);
+    const parsed = JSON.parse(cleaned);
+    expect(parsed.evaluations).toHaveLength(2);
+    expect(parsed.evaluations[0].is_valuable).toBe(true);
+    expect(parsed.evaluations[1].is_valuable).toBe(false);
+  });
+});
+
+describe('Integration: live MiniMax API call', () => {
+  const apiKey = process.env.MINIMAX_API_KEY;
+
+  it.skipIf(!apiKey)('should successfully call MiniMax chat completions API', async () => {
+    const config = {
+      provider: 'minimax',
+      baseUrl: 'https://api.minimax.io/v1',
+      apiKey,
+      model: 'MiniMax-M2.5-highspeed',
+    };
+
+    const messages = [
+      { role: 'system', content: 'Respond ONLY with valid JSON.' },
+      { role: 'user', content: 'Return a JSON object with a single key "status" and value "ok".' },
+    ];
+
+    const body = buildRequestBody(config.provider, config.model, messages, {
+      temperature: 0.1,
+      responseFormat: { type: 'json_object' },
+    });
+
+    const res = await fetch(`${config.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    expect(res.ok).toBe(true);
+
+    const data = await res.json();
+    expect(data.choices).toBeDefined();
+    expect(data.choices.length).toBeGreaterThan(0);
+
+    let content = data.choices[0].message.content;
+    content = stripThinkTags(content);
+    const parsed = JSON.parse(content);
+    expect(parsed.status).toBe('ok');
+  }, 30000);
+});

--- a/tests/llm-provider.test.js
+++ b/tests/llm-provider.test.js
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  PROVIDER_PRESETS,
+  detectProvider,
+  clampTemperature,
+  resolveLLMConfig,
+  buildRequestBody,
+  stripThinkTags,
+} from '../scripts/llm-provider.js';
+
+/* ------------------------------------------------------------------ */
+/*  PROVIDER_PRESETS                                                   */
+/* ------------------------------------------------------------------ */
+describe('PROVIDER_PRESETS', () => {
+  it('should contain openai, minimax, deepseek, and ollama presets', () => {
+    expect(PROVIDER_PRESETS).toHaveProperty('openai');
+    expect(PROVIDER_PRESETS).toHaveProperty('minimax');
+    expect(PROVIDER_PRESETS).toHaveProperty('deepseek');
+    expect(PROVIDER_PRESETS).toHaveProperty('ollama');
+  });
+
+  it('minimax preset should use api.minimax.io base URL', () => {
+    expect(PROVIDER_PRESETS.minimax.baseUrl).toBe('https://api.minimax.io/v1');
+  });
+
+  it('minimax preset should default to MiniMax-M2.5 model', () => {
+    expect(PROVIDER_PRESETS.minimax.defaultModel).toBe('MiniMax-M2.5');
+  });
+
+  it('minimax preset should have temperature range [0, 1]', () => {
+    expect(PROVIDER_PRESETS.minimax.temperatureRange).toEqual([0, 1]);
+  });
+
+  it('minimax preset should list available models', () => {
+    expect(PROVIDER_PRESETS.minimax.models).toContain('MiniMax-M2.7');
+    expect(PROVIDER_PRESETS.minimax.models).toContain('MiniMax-M2.5');
+    expect(PROVIDER_PRESETS.minimax.models).toContain('MiniMax-M2.5-highspeed');
+  });
+
+  it('minimax preset should use MINIMAX_API_KEY env var', () => {
+    expect(PROVIDER_PRESETS.minimax.envKey).toBe('MINIMAX_API_KEY');
+  });
+
+  it('openai preset should have temperature range [0, 2]', () => {
+    expect(PROVIDER_PRESETS.openai.temperatureRange).toEqual([0, 2]);
+  });
+
+  it('each preset should have required fields', () => {
+    for (const [key, preset] of Object.entries(PROVIDER_PRESETS)) {
+      expect(preset).toHaveProperty('name');
+      expect(preset).toHaveProperty('baseUrl');
+      expect(preset).toHaveProperty('defaultModel');
+      expect(preset).toHaveProperty('temperatureRange');
+      expect(preset.temperatureRange).toHaveLength(2);
+    }
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  detectProvider                                                      */
+/* ------------------------------------------------------------------ */
+describe('detectProvider', () => {
+  const envBackup = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...envBackup };
+  });
+
+  it('should detect minimax from base URL containing "minimax"', () => {
+    expect(detectProvider('key', 'https://api.minimax.io/v1')).toBe('minimax');
+  });
+
+  it('should detect deepseek from base URL', () => {
+    expect(detectProvider('key', 'https://api.deepseek.com/v1')).toBe('deepseek');
+  });
+
+  it('should detect openai from base URL', () => {
+    expect(detectProvider('key', 'https://api.openai.com/v1')).toBe('openai');
+  });
+
+  it('should detect ollama from localhost URL', () => {
+    expect(detectProvider('key', 'http://127.0.0.1:11434/v1')).toBe('ollama');
+    expect(detectProvider('key', 'http://localhost:11434/v1')).toBe('ollama');
+  });
+
+  it('should detect minimax from MINIMAX_API_KEY env var', () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    expect(detectProvider('', '')).toBe('minimax');
+  });
+
+  it('should detect deepseek from DEEPSEEK_API_KEY env var', () => {
+    delete process.env.MINIMAX_API_KEY;
+    process.env.DEEPSEEK_API_KEY = 'test-key';
+    expect(detectProvider('', '')).toBe('deepseek');
+  });
+
+  it('should default to openai when API key is provided without URL', () => {
+    delete process.env.MINIMAX_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
+    expect(detectProvider('sk-test', '')).toBe('openai');
+  });
+
+  it('should default to ollama when no API key or URL', () => {
+    delete process.env.MINIMAX_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
+    expect(detectProvider('', '')).toBe('ollama');
+    expect(detectProvider('local-fallback', '')).toBe('ollama');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  clampTemperature                                                    */
+/* ------------------------------------------------------------------ */
+describe('clampTemperature', () => {
+  it('should clamp temperature to minimax range [0, 1]', () => {
+    expect(clampTemperature(1.5, 'minimax')).toBe(1);
+    expect(clampTemperature(0.5, 'minimax')).toBe(0.5);
+    expect(clampTemperature(0, 'minimax')).toBe(0);
+    expect(clampTemperature(-0.1, 'minimax')).toBe(0);
+  });
+
+  it('should allow temperature up to 2 for openai', () => {
+    expect(clampTemperature(1.5, 'openai')).toBe(1.5);
+    expect(clampTemperature(2, 'openai')).toBe(2);
+    expect(clampTemperature(2.5, 'openai')).toBe(2);
+  });
+
+  it('should return original value for unknown provider', () => {
+    expect(clampTemperature(5, 'unknown-provider')).toBe(5);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  resolveLLMConfig                                                    */
+/* ------------------------------------------------------------------ */
+describe('resolveLLMConfig', () => {
+  const envBackup = { ...process.env };
+
+  beforeEach(() => {
+    // Clear all relevant env vars
+    delete process.env.LLM_PROVIDER;
+    delete process.env.LLM_API_KEY;
+    delete process.env.LLM_BASE_URL;
+    delete process.env.LLM_MODEL;
+    delete process.env.MINIMAX_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...envBackup };
+  });
+
+  it('should use explicit LLM_PROVIDER when set', () => {
+    process.env.LLM_PROVIDER = 'minimax';
+    process.env.LLM_API_KEY = 'test-key';
+    const config = resolveLLMConfig();
+    expect(config.provider).toBe('minimax');
+    expect(config.baseUrl).toBe('https://api.minimax.io/v1');
+    expect(config.model).toBe('MiniMax-M2.5');
+  });
+
+  it('should use provider-specific env key when LLM_API_KEY is empty', () => {
+    process.env.LLM_PROVIDER = 'minimax';
+    process.env.MINIMAX_API_KEY = 'mm-key-123';
+    const config = resolveLLMConfig();
+    expect(config.apiKey).toBe('mm-key-123');
+  });
+
+  it('should override model with LLM_MODEL env var', () => {
+    process.env.LLM_PROVIDER = 'minimax';
+    process.env.LLM_MODEL = 'MiniMax-M2.7';
+    const config = resolveLLMConfig();
+    expect(config.model).toBe('MiniMax-M2.7');
+  });
+
+  it('should override base URL with LLM_BASE_URL env var', () => {
+    process.env.LLM_PROVIDER = 'minimax';
+    process.env.LLM_BASE_URL = 'https://custom-proxy.example.com/v1';
+    const config = resolveLLMConfig();
+    expect(config.baseUrl).toBe('https://custom-proxy.example.com/v1');
+  });
+
+  it('should fallback to ollama when no keys set', () => {
+    const config = resolveLLMConfig();
+    expect(config.provider).toBe('ollama');
+    expect(config.model).toBe('llama3');
+    expect(config.apiKey).toBe('local-fallback');
+  });
+
+  it('should auto-detect minimax from MINIMAX_API_KEY', () => {
+    process.env.MINIMAX_API_KEY = 'mm-key';
+    const config = resolveLLMConfig();
+    expect(config.provider).toBe('minimax');
+    expect(config.apiKey).toBe('mm-key');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  buildRequestBody                                                    */
+/* ------------------------------------------------------------------ */
+describe('buildRequestBody', () => {
+  it('should clamp temperature for minimax provider', () => {
+    const body = buildRequestBody('minimax', 'MiniMax-M2.5', [], {
+      temperature: 1.5,
+    });
+    expect(body.temperature).toBe(1);
+  });
+
+  it('should keep temperature within range for openai', () => {
+    const body = buildRequestBody('openai', 'gpt-4o-mini', [], {
+      temperature: 1.5,
+    });
+    expect(body.temperature).toBe(1.5);
+  });
+
+  it('should include response_format when provided', () => {
+    const body = buildRequestBody('minimax', 'MiniMax-M2.5', [], {
+      responseFormat: { type: 'json_object' },
+    });
+    expect(body.response_format).toEqual({ type: 'json_object' });
+  });
+
+  it('should not include response_format when not provided', () => {
+    const body = buildRequestBody('minimax', 'MiniMax-M2.5', []);
+    expect(body).not.toHaveProperty('response_format');
+  });
+
+  it('should set model and messages correctly', () => {
+    const msgs = [{ role: 'user', content: 'Hello' }];
+    const body = buildRequestBody('minimax', 'MiniMax-M2.5', msgs);
+    expect(body.model).toBe('MiniMax-M2.5');
+    expect(body.messages).toBe(msgs);
+  });
+
+  it('should default temperature to 0.1 when not specified', () => {
+    const body = buildRequestBody('minimax', 'MiniMax-M2.5', []);
+    expect(body.temperature).toBe(0.1);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  stripThinkTags                                                      */
+/* ------------------------------------------------------------------ */
+describe('stripThinkTags', () => {
+  it('should remove think tags and their content', () => {
+    const input = '<think>reasoning here</think>{"result": true}';
+    expect(stripThinkTags(input)).toBe('{"result": true}');
+  });
+
+  it('should handle multiline think tags', () => {
+    const input = '<think>\nStep 1: ...\nStep 2: ...\n</think>\n{"evaluations": []}';
+    expect(stripThinkTags(input)).toBe('{"evaluations": []}');
+  });
+
+  it('should return original text when no think tags present', () => {
+    const input = '{"evaluations": []}';
+    expect(stripThinkTags(input)).toBe('{"evaluations": []}');
+  });
+
+  it('should handle multiple think tag blocks', () => {
+    const input = '<think>a</think>hello<think>b</think>world';
+    expect(stripThinkTags(input)).toBe('helloworld');
+  });
+
+  it('should handle empty think tags', () => {
+    const input = '<think></think>result';
+    expect(stripThinkTags(input)).toBe('result');
+  });
+});


### PR DESCRIPTION
## Summary

- Add a multi-provider preset system (`scripts/llm-provider.js`) supporting **OpenAI**, **MiniMax**, **DeepSeek**, and **Ollama** with auto-detection
- MiniMax models: `MiniMax-M2.7`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed` — fully OpenAI-compatible API at `api.minimax.io/v1`
- Temperature clamping per provider (MiniMax: 0–1), `<think>` tag stripping for reasoning models
- Update `discover-and-evaluate.js` to use the new provider module
- Update `.env.example`, `README.md`, `README-zh.md` with provider table and quick-start docs

## Changes

| File | Change |
|------|--------|
| `scripts/llm-provider.js` | New provider presets module with auto-detect, temp clamping, think-tag strip |
| `scripts/discover-and-evaluate.js` | Refactored to use `llm-provider.js` instead of inline config |
| `.env.example` | Added `LLM_PROVIDER` and provider-specific API key vars |
| `README.md` | Added supported providers table and MiniMax quick-start |
| `README-zh.md` | Added Chinese provider docs |
| `tests/llm-provider.test.js` | 36 unit tests |
| `tests/llm-provider.integration.test.js` | 4 integration tests (including live MiniMax API call) |

## Quick Start with MiniMax

```env
LLM_PROVIDER=minimax
MINIMAX_API_KEY=your-key-here
```

## Test Plan

- [x] 36 unit tests passing (`npx vitest run tests/llm-provider.test.js`)
- [x] 4 integration tests passing, including live MiniMax API call
- [ ] Verify backward compatibility: existing OpenAI/Ollama configs continue to work unchanged
- [ ] Test with `npm run ai:discover-eval` using MiniMax provider