### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ LLM_API_KEY=
 # Local or Remote LLM URL (Ollama example: http://127.0.0.1:11434/v1)
 LLM_BASE_URL=
 
-# Model Name (e.g., gpt-4o-mini, MiniMax-M2.5, deepseek-chat, llama3)
+# Model Name (e.g., gpt-4o-mini, MiniMax-M3, deepseek-chat, llama3)
 LLM_MODEL=
 
 # Provider-specific API keys (used when LLM_API_KEY is not set)

--- a/README-zh.md
+++ b/README-zh.md
@@ -163,7 +163,7 @@ cp .env.example .env
   - *💡 零成本本地提示：如果你在使用本地部署大模型（如 Ollama + llama3），可以将其设为 `local-fallback`。*
 - **`LLM_PROVIDER=`**：选择内置供应商预设（`openai`、`minimax`、`deepseek`、`ollama`）。省略时会根据 `LLM_BASE_URL` 或对应的 API Key 环境变量自动检测。
 - **`LLM_BASE_URL=`**：API转发地址（例如：`https://api.openai.com/v1` 或 本地 `http://127.0.0.1:11434/v1`）。
-- **`LLM_MODEL=`**：要执行推理的模型名字（如 `gpt-4o-mini`、`MiniMax-M2.5`）。
+- **`LLM_MODEL=`**：要执行推理的模型名字（如 `gpt-4o-mini`、`MiniMax-M3`）。
 - **`DISCOVER_BATCH_SIZE`** / **`EVALUATE_BATCH_SIZE`** / **`UPDATE_STATUS_BATCH_SIZE`**：控制每次探索拉取的个数、一次批量合并扔给 AI 判断的项目个数，以及状态更新时的批处理大小。
 - **`LOOP_INTERVAL_SECONDS`**: 可调整 `ai:loop-eval` 循环模式每次休息的打底时间（默认 60 秒）。
 - **`UPDATE_STATUS_INTERVAL_SECONDS`**: 可调整 `ai:update-status:loop` 状态更新循环模式每次休息的打底时间（默认 60 秒）。
@@ -180,7 +180,7 @@ cp .env.example .env
 | 供应商 | `LLM_PROVIDER` | 默认模型 | API Key 环境变量 |
 |--------|----------------|----------|-----------------|
 | [OpenAI](https://openai.com) | `openai` | `gpt-4o-mini` | `OPENAI_API_KEY` 或 `LLM_API_KEY` |
-| [MiniMax](https://www.minimaxi.com) | `minimax` | `MiniMax-M2.5` | `MINIMAX_API_KEY` 或 `LLM_API_KEY` |
+| [MiniMax](https://www.minimaxi.com) | `minimax` | `MiniMax-M3` | `MINIMAX_API_KEY` 或 `LLM_API_KEY` |
 | [DeepSeek](https://deepseek.com) | `deepseek` | `deepseek-chat` | `DEEPSEEK_API_KEY` 或 `LLM_API_KEY` |
 | [Ollama](https://ollama.ai) (本地) | `ollama` | `llama3` | 不需要（使用 `local-fallback`） |
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Open `.env` and adjust the core configurations:
   - *💡 Zero-Cost Prompt: If you are using a local LLM setup (e.g. Ollama via llama3), you can simply use `LLM_API_KEY=local-fallback`.*
 - **`LLM_PROVIDER=`**: Select a built-in provider preset (`openai`, `minimax`, `deepseek`, `ollama`). When omitted, auto-detected from `LLM_BASE_URL` or provider-specific API key env vars.
 - **`LLM_BASE_URL=`**: LLM endpoint (e.g. `https://api.openai.com/v1`, or local `http://127.0.0.1:11434/v1`).
-- **`LLM_MODEL=`**: Standard model identity to use (e.g. `gpt-4o-mini`, `MiniMax-M2.5`).
+- **`LLM_MODEL=`**: Standard model identity to use (e.g. `gpt-4o-mini`, `MiniMax-M3`).
 - **`DISCOVER_BATCH_SIZE`** / **`EVALUATE_BATCH_SIZE`** / **`UPDATE_STATUS_BATCH_SIZE`**: Modify limits per pull from GitHub, per LLM prompt, and for status update batching.
 - **`LOOP_INTERVAL_SECONDS`**: Configure the base idle time interval between consecutive `ai:loop-eval` cycles (default: 60s).
 - **`MAX_PAGES_DEFAULT`**: Default max pages to explore per topic (default: 5).
@@ -156,7 +156,7 @@ The evaluation engine supports any **OpenAI-compatible** LLM API. Built-in prese
 | Provider | `LLM_PROVIDER` | Default Model | API Key Env |
 |----------|----------------|---------------|-------------|
 | [OpenAI](https://openai.com) | `openai` | `gpt-4o-mini` | `OPENAI_API_KEY` or `LLM_API_KEY` |
-| [MiniMax](https://www.minimaxi.com) | `minimax` | `MiniMax-M2.5` | `MINIMAX_API_KEY` or `LLM_API_KEY` |
+| [MiniMax](https://www.minimaxi.com) | `minimax` | `MiniMax-M3` | `MINIMAX_API_KEY` or `LLM_API_KEY` |
 | [DeepSeek](https://deepseek.com) | `deepseek` | `deepseek-chat` | `DEEPSEEK_API_KEY` or `LLM_API_KEY` |
 | [Ollama](https://ollama.ai) (local) | `ollama` | `llama3` | N/A (uses `local-fallback`) |
 

--- a/scripts/llm-provider.js
+++ b/scripts/llm-provider.js
@@ -18,10 +18,10 @@ const PROVIDER_PRESETS = {
   minimax: {
     name: 'MiniMax',
     baseUrl: 'https://api.minimax.io/v1',
-    defaultModel: 'MiniMax-M2.5',
+    defaultModel: 'MiniMax-M3',
     envKey: 'MINIMAX_API_KEY',
     temperatureRange: [0, 1],
-    models: ['MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+    models: ['MiniMax-M3', 'MiniMax-M2.7'],
   },
   deepseek: {
     name: 'DeepSeek',
@@ -132,7 +132,7 @@ function buildRequestBody(provider, model, messages, options = {}) {
 }
 
 /**
- * Strip <think>…</think> tags that some models (e.g. MiniMax-M2.5) may
+ * Strip <think>…</think> tags that some models (e.g. MiniMax-M3) may
  * include in their responses.
  */
 function stripThinkTags(text) {

--- a/tests/llm-provider.integration.test.js
+++ b/tests/llm-provider.integration.test.js
@@ -43,7 +43,7 @@ describe('Integration: provider config resolution', () => {
       responseFormat: { type: 'json_object' },
     });
 
-    expect(body.model).toBe('MiniMax-M2.5');
+    expect(body.model).toBe('MiniMax-M3');
     expect(body.temperature).toBe(0.1);
     expect(body.response_format).toEqual({ type: 'json_object' });
     expect(body.messages).toHaveLength(2);
@@ -59,7 +59,7 @@ describe('Integration: provider config resolution', () => {
     const config = resolveLLMConfig();
     expect(config.provider).toBe('minimax');
     expect(config.baseUrl).toBe('https://api.minimax.io/v1');
-    expect(config.model).toBe('MiniMax-M2.5');
+    expect(config.model).toBe('MiniMax-M3');
     expect(config.apiKey).toBe('mm-test-key');
   });
 
@@ -101,7 +101,7 @@ describe('Integration: live MiniMax API call', () => {
       provider: 'minimax',
       baseUrl: 'https://api.minimax.io/v1',
       apiKey,
-      model: 'MiniMax-M2.5-highspeed',
+      model: 'MiniMax-M3',
     };
 
     const messages = [

--- a/tests/llm-provider.test.js
+++ b/tests/llm-provider.test.js
@@ -23,8 +23,8 @@ describe('PROVIDER_PRESETS', () => {
     expect(PROVIDER_PRESETS.minimax.baseUrl).toBe('https://api.minimax.io/v1');
   });
 
-  it('minimax preset should default to MiniMax-M2.5 model', () => {
-    expect(PROVIDER_PRESETS.minimax.defaultModel).toBe('MiniMax-M2.5');
+  it('minimax preset should default to MiniMax-M3 model', () => {
+    expect(PROVIDER_PRESETS.minimax.defaultModel).toBe('MiniMax-M3');
   });
 
   it('minimax preset should have temperature range [0, 1]', () => {
@@ -32,9 +32,8 @@ describe('PROVIDER_PRESETS', () => {
   });
 
   it('minimax preset should list available models', () => {
+    expect(PROVIDER_PRESETS.minimax.models).toContain('MiniMax-M3');
     expect(PROVIDER_PRESETS.minimax.models).toContain('MiniMax-M2.7');
-    expect(PROVIDER_PRESETS.minimax.models).toContain('MiniMax-M2.5');
-    expect(PROVIDER_PRESETS.minimax.models).toContain('MiniMax-M2.5-highspeed');
   });
 
   it('minimax preset should use MINIMAX_API_KEY env var', () => {
@@ -157,7 +156,7 @@ describe('resolveLLMConfig', () => {
     const config = resolveLLMConfig();
     expect(config.provider).toBe('minimax');
     expect(config.baseUrl).toBe('https://api.minimax.io/v1');
-    expect(config.model).toBe('MiniMax-M2.5');
+    expect(config.model).toBe('MiniMax-M3');
   });
 
   it('should use provider-specific env key when LLM_API_KEY is empty', () => {
@@ -201,7 +200,7 @@ describe('resolveLLMConfig', () => {
 /* ------------------------------------------------------------------ */
 describe('buildRequestBody', () => {
   it('should clamp temperature for minimax provider', () => {
-    const body = buildRequestBody('minimax', 'MiniMax-M2.5', [], {
+    const body = buildRequestBody('minimax', 'MiniMax-M3', [], {
       temperature: 1.5,
     });
     expect(body.temperature).toBe(1);
@@ -215,26 +214,26 @@ describe('buildRequestBody', () => {
   });
 
   it('should include response_format when provided', () => {
-    const body = buildRequestBody('minimax', 'MiniMax-M2.5', [], {
+    const body = buildRequestBody('minimax', 'MiniMax-M3', [], {
       responseFormat: { type: 'json_object' },
     });
     expect(body.response_format).toEqual({ type: 'json_object' });
   });
 
   it('should not include response_format when not provided', () => {
-    const body = buildRequestBody('minimax', 'MiniMax-M2.5', []);
+    const body = buildRequestBody('minimax', 'MiniMax-M3', []);
     expect(body).not.toHaveProperty('response_format');
   });
 
   it('should set model and messages correctly', () => {
     const msgs = [{ role: 'user', content: 'Hello' }];
-    const body = buildRequestBody('minimax', 'MiniMax-M2.5', msgs);
-    expect(body.model).toBe('MiniMax-M2.5');
+    const body = buildRequestBody('minimax', 'MiniMax-M3', msgs);
+    expect(body.model).toBe('MiniMax-M3');
     expect(body.messages).toBe(msgs);
   });
 
   it('should default temperature to 0.1 when not specified', () => {
-    const body = buildRequestBody('minimax', 'MiniMax-M2.5', []);
+    const body = buildRequestBody('minimax', 'MiniMax-M3', []);
     expect(body.temperature).toBe(0.1);
   });
 });


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as default.

## Changes
- Add MiniMax-M3 to the model selection list
- Set MiniMax-M3 as the new default model
- Retain MiniMax-M2.7 as available alternative
- Remove deprecated older versions (MiniMax-M2.5 / MiniMax-M2.5-highspeed) from the list
- Update related unit and integration tests
- Update README docs and .env.example

## Why
MiniMax-M3 is the new flagship model with 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces.

## Testing
- Unit tests updated and passing
- Integration tested with MiniMax API